### PR TITLE
Add fibers and cancellation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --maxWorkers 2",
     "lint": "prettier --check 'src/**.ts' 'tests/**.ts'",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "jest --forceExit",
+    "test": "jest",
     "lint": "prettier --check 'src/**.ts' 'tests/**.ts'",
     "prepare": "npm run build",
     "prepublishOnly": "npm test",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,3 +3,9 @@ export class TimeoutError extends Error {
     super("Time limit exceeded");
   }
 }
+
+export class CancellationError extends Error {
+  constructor() {
+    super("Execution of this fiber was canceled");
+  }
+}

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -22,12 +22,16 @@ export class Fiber<A, E> {
   }
 
   outcome(): IO<IOResult<A, E>, never> {
-    return IO(() => this.promise).castError<never>();
+    return IO(() => this.promise).catch((unsoundlyThrownError) => {
+      throw unsoundlyThrownError;
+    });
   }
 
   cancel(): IO<void, never> {
     return IO(() => {
       if (this.cancelCurrentEffect) this.cancelCurrentEffect();
-    }).castError<never>();
+    }).catch((unsoundlyThrownError) => {
+      throw unsoundlyThrownError;
+    });
   }
 }

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -2,7 +2,7 @@ import { IO, IOResult } from "./io";
 
 const TRACE_FIBERS = false;
 
-export class Fiber<A, E> {
+export class Fiber<A = unknown, E = unknown> {
   // Assign each fiber a unique ID for debugging.
   private static nextId = 0;
   id = Fiber.nextId++;

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -1,0 +1,17 @@
+import { IO, IOResult } from "./io";
+
+export class Fiber<A, E> {
+  private readonly promise: Promise<IOResult<A, E>>;
+
+  constructor(action: IO<A, E>) {
+    this.promise = action.runSafe();
+  }
+
+  static start<A, E>(action: IO<A, E>): IO<Fiber<A, E>, never> {
+    return IO.wrap(new Fiber(action));
+  }
+
+  outcome(): IO<IOResult<A, E>, never> {
+    return IO(() => this.promise).castError<never>();
+  }
+}

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -1,18 +1,34 @@
 import { IO, IOResult } from "./io";
 
 export class Fiber<A, E> {
+  private static nextId = 0;
+  id = Fiber.nextId++;
+
+  private cancelCurrentEffect: (() => void) | null = null;
+  private isCanceled = false;
   private readonly promise: Promise<IOResult<A, E>>;
 
   constructor(action: IO<A, E>) {
-    // Horrible type-cast needed to call the private executeOn method.
-    this.promise = (action as any).executeOn(this);
+    this.promise = this._execute(action);
   }
 
   static start<A, E>(action: IO<A, E>): IO<Fiber<A, E>, never> {
     return IO.wrap(new Fiber(action));
   }
 
+  async _execute<A2, E2>(action: IO<A2, E2>): Promise<IOResult<A2, E2>> {
+    // Horrible type-cast needed to call the private executeOn method.
+    return (action as any).executeOn(this);
+  }
+
   outcome(): IO<IOResult<A, E>, never> {
     return IO(() => this.promise).castError<never>();
+  }
+
+  cancel(): IO<void, never> {
+    return IO(() => {
+      this.isCanceled = true;
+      if (this.cancelCurrentEffect) this.cancelCurrentEffect();
+    }).castError<never>();
   }
 }

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -5,7 +5,7 @@ export class Fiber<A, E> {
   private static nextId = 0;
   id = Fiber.nextId++;
 
-  private cancelCurrentEffect: (() => void) | null = null;
+  private cancelCurrentEffect = () => {};
   private readonly promise: Promise<IOResult<A, E>>;
 
   constructor(action: IO<A, E>) {
@@ -29,7 +29,7 @@ export class Fiber<A, E> {
 
   cancel(): IO<void, never> {
     return IO(() => {
-      if (this.cancelCurrentEffect) this.cancelCurrentEffect();
+      this.cancelCurrentEffect();
     }).catch((unsoundlyThrownError) => {
       throw unsoundlyThrownError;
     });

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -4,7 +4,8 @@ export class Fiber<A, E> {
   private readonly promise: Promise<IOResult<A, E>>;
 
   constructor(action: IO<A, E>) {
-    this.promise = action.runSafe();
+    // Horrible type-cast needed to call the private executeOn method.
+    this.promise = (action as any).executeOn(this);
   }
 
   static start<A, E>(action: IO<A, E>): IO<Fiber<A, E>, never> {

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -1,5 +1,7 @@
 import { IO, IOResult } from "./io";
 
+const TRACE_FIBERS = false;
+
 export class Fiber<A, E> {
   // Assign each fiber a unique ID for debugging.
   private static nextId = 0;
@@ -9,11 +11,12 @@ export class Fiber<A, E> {
   private readonly promise: Promise<IOResult<A, E>>;
 
   constructor(action: IO<A, E>) {
+    if (TRACE_FIBERS) console.log(`starting fiber ${this.id}`);
     this.promise = this._execute(action);
   }
 
   static start<A, E>(action: IO<A, E>): IO<Fiber<A, E>, never> {
-    return IO.wrap(new Fiber(action));
+    return IO(() => new Fiber(action)).castError<never>();
   }
 
   async _execute<A2, E2>(action: IO<A2, E2>): Promise<IOResult<A2, E2>> {
@@ -29,6 +32,7 @@ export class Fiber<A, E> {
 
   cancel(): IO<void, never> {
     return IO(() => {
+      if (TRACE_FIBERS) console.log(`canceling fiber ${this.id}`);
       this.cancelCurrentEffect();
     }).catch((unsoundlyThrownError) => {
       throw unsoundlyThrownError;

--- a/src/fiber.ts
+++ b/src/fiber.ts
@@ -1,11 +1,11 @@
 import { IO, IOResult } from "./io";
 
 export class Fiber<A, E> {
+  // Assign each fiber a unique ID for debugging.
   private static nextId = 0;
   id = Fiber.nextId++;
 
   private cancelCurrentEffect: (() => void) | null = null;
-  private isCanceled = false;
   private readonly promise: Promise<IOResult<A, E>>;
 
   constructor(action: IO<A, E>) {
@@ -27,7 +27,6 @@ export class Fiber<A, E> {
 
   cancel(): IO<void, never> {
     return IO(() => {
-      this.isCanceled = true;
       if (this.cancelCurrentEffect) this.cancelCurrentEffect();
     }).castError<never>();
   }

--- a/src/io.ts
+++ b/src/io.ts
@@ -2,7 +2,7 @@ import { CancellationError, TimeoutError } from "./errors";
 
 export { TimeoutError };
 
-type IO<A, E = unknown> =
+export type IO<A, E = unknown> =
   | Wrap<A, E>
   | Defer<A, E>
   | AndThen<A, E, any, E>
@@ -170,6 +170,10 @@ abstract class IOBase<A, E = unknown> {
 
     return nextAttempt(0);
   }
+
+  castError<CastedError>(): IO<A, CastedError> {
+    return (this as unknown) as IO<A, CastedError>;
+  }
 }
 
 class Wrap<A, E> extends IOBase<A, E> {
@@ -264,7 +268,7 @@ class Cancel<A, E> extends IOBase<A, E> {
   }
 }
 
-function IO<A>(effect: () => Promise<A> | A): IO<A, unknown> {
+export function IO<A>(effect: () => Promise<A> | A): IO<A, unknown> {
   return new Defer(effect);
 }
 
@@ -485,4 +489,5 @@ IO.wait = wait;
 // implementations in tests.
 IO._setTimeout = setTimeout;
 
+export { Fiber } from "./fiber";
 export default IO;

--- a/src/io.ts
+++ b/src/io.ts
@@ -442,8 +442,10 @@ function parallel<Actions extends IOArray>(
                   : cancelAll(fibers)
               )
           )
-            .andThen((fiber) => fiber.outcome())
-            .andThen(IOResult.toIO)
+        )
+      ).andThen((cancellationFibers) =>
+        IO.sequence(
+          cancellationFibers.map((f) => f.outcome().andThen(IOResult.toIO))
         )
       )
     )

--- a/src/io.ts
+++ b/src/io.ts
@@ -230,9 +230,6 @@ class AndThen<A, E, ParentA, ParentE extends E> extends IOBase<A, E> {
     // TODO attempt to find a way to implement this function
     //      with type safety.
 
-    // Are there other boundaries where we need to check for cancellation?
-    if (fiber["isCanceled"]) return IOResult.Canceled;
-
     let io: IO<A, E> = this;
 
     // Trampoline the andThen operation to ensure stack safety.

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -3,9 +3,16 @@ import IO from "./io";
 export class Ref<A> {
   constructor(private currentValue: A) {
     this.get = IO(() => this.currentValue).castError<never>();
+
     this.set = (newValue: A) =>
       IO(() => {
         this.currentValue = newValue;
+      }).castError<never>();
+
+    this.modify = (modifier) =>
+      IO(() => {
+        this.currentValue = modifier(this.currentValue);
+        return this.currentValue;
       }).castError<never>();
   }
 
@@ -19,4 +26,6 @@ export class Ref<A> {
 
   get: IO<A, never>;
   set: (newValue: A) => IO<void, never>;
+
+  modify: (modifier: (currentValue: A) => A) => IO<A, never>;
 }

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -1,0 +1,22 @@
+import IO from "./io";
+
+export class Ref<A> {
+  constructor(private currentValue: A) {
+    this.get = IO(() => this.currentValue).castError<never>();
+    this.set = (newValue: A) =>
+      IO(() => {
+        this.currentValue = newValue;
+      }).castError<never>();
+  }
+
+  static create<A>(initialValue: A): IO<Ref<A>, never> {
+    return IO(() => new Ref(initialValue)).castError<never>();
+  }
+
+  static empty<A>(): IO<Ref<A | null>, never> {
+    return Ref.create<A | null>(null);
+  }
+
+  get: IO<A, never>;
+  set: (newValue: A) => IO<void, never>;
+}

--- a/src/ref.ts
+++ b/src/ref.ts
@@ -24,8 +24,21 @@ export class Ref<A> {
     return Ref.create<A | null>(null);
   }
 
+  static get<A>(ref: Ref<A>): IO<A, never> {
+    return ref.get;
+  }
+
+  static set<A>(newValue: A): (ref: Ref<A>) => IO<void, never> {
+    return (ref) => ref.set(newValue);
+  }
+
+  static modify<A>(
+    modifier: (currentValue: A) => A
+  ): (ref: Ref<A>) => IO<A, never> {
+    return (ref) => ref.modify(modifier);
+  }
+
   get: IO<A, never>;
   set: (newValue: A) => IO<void, never>;
-
   modify: (modifier: (currentValue: A) => A) => IO<A, never>;
 }

--- a/tests/arbitraries.ts
+++ b/tests/arbitraries.ts
@@ -29,7 +29,8 @@ export const unsuccessfulIo: Arbitrary<IO<unknown>> = fc
 
 export const io: Arbitrary<IO<unknown>> = fc.oneof(
   successfulIo,
-  unsuccessfulIo
+  unsuccessfulIo,
+  fc.constant(IO.cancel())
 );
 
 export const unaryFunction: Arbitrary<

--- a/tests/bracket.test.ts
+++ b/tests/bracket.test.ts
@@ -90,9 +90,9 @@ describe("The IO.bracket function", () => {
     const open = IO.void.delay(30, "seconds");
     const close = jest.fn(() => IO.void);
     const use = jest.fn(() => IO.void);
+
     const io = Fiber.start(IO.bracket(open, close)(use))
-      .through(() => IO.wait(200, "milliseconds"))
-      .through((fiber) => fiber.cancel())
+      .through((fiber) => fiber.cancel().delay(200, "milliseconds"))
       .andThen((fiber) => fiber.outcome());
 
     const outcome = await io.run();
@@ -105,23 +105,23 @@ describe("The IO.bracket function", () => {
     const open = IO.void;
     const close = jest.fn(() => IO.void);
     const use = jest.fn(() => IO.void.delay(30, "seconds"));
+
     const io = Fiber.start(IO.bracket(open, close)(use))
-      .through(() => IO.wait(200, "milliseconds"))
-      .through((fiber) => fiber.cancel())
+      .through((fiber) => fiber.cancel().delay(200, "milliseconds"))
       .andThen((fiber) => fiber.outcome());
 
     const outcome = await io.run();
     expect(outcome).toEqual(IOResult.Canceled);
-    expect(close).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalled();
   });
 
   it("Will allow cancellation of the close action", async () => {
     const open = IO.void;
     const close = jest.fn(() => IO.void.delay(30, "seconds"));
     const use = jest.fn(() => IO.void);
+
     const io = Fiber.start(IO.bracket(open, close)(use))
-      .through(() => IO.wait(200, "milliseconds"))
-      .through((fiber) => fiber.cancel())
+      .through((fiber) => fiber.cancel().delay(200, "milliseconds"))
       .andThen((fiber) => fiber.outcome());
 
     const outcome = await io.run();

--- a/tests/bracket.test.ts
+++ b/tests/bracket.test.ts
@@ -1,5 +1,5 @@
 import fc from "fast-check";
-import IO from "../src/io";
+import IO, { Fiber } from "../src/io";
 import * as arbitraries from "./arbitraries";
 
 describe("The IO.bracket function", () => {
@@ -72,4 +72,17 @@ describe("The IO.bracket function", () => {
         );
       })
     ));
+
+  it("Will call the close function even if the fiber is immediately canceled", async () => {
+    const open = IO.void;
+    const close = jest.fn(() => IO.void);
+    const use = () => IO.void;
+    const io = Fiber.start(IO.bracket(open, close)(use)).andThen((fiber) =>
+      fiber.cancel()
+    );
+
+    await io.runSafe();
+
+    expect(close).toHaveBeenCalled();
+  });
 });

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -1,5 +1,6 @@
+import fc from "fast-check";
 import { CancellationError } from "../src/errors";
-import IO, { IOOutcome } from "../src/io";
+import IO, { Fiber, IOOutcome, IOResult } from "../src/io";
 
 describe("The IO.cancel function", () => {
   it("gives an IO which results in the 'canceled' outcome", async () => {
@@ -18,5 +19,80 @@ describe("The IO.cancel function", () => {
     );
     await io.runSafe();
     expect(subsequentEffectHasRun).toBe(false);
+  });
+});
+
+describe("The IO.cancelable function", () => {
+  it("creates an IO which performs the side-effect when run", () =>
+    fc.assert(
+      fc.asyncProperty(fc.anything(), (effectResult) => {
+        let effectPerformedCount = 0;
+        const io = IO.cancelable(() => {
+          effectPerformedCount += 1;
+          return {
+            promise: Promise.resolve(effectResult),
+            cancel: () => {},
+          };
+        });
+        expect(effectPerformedCount).toBe(0);
+        const result = io.run();
+        expect(effectPerformedCount).toBe(1);
+        return expect(result).resolves.toBe(effectResult);
+      })
+    ));
+
+  it("creates an IO which rejects when run if the side-effect throws", () =>
+    fc.assert(
+      fc.asyncProperty(fc.anything(), (thrownValue) => {
+        const io = IO.cancelable(() => {
+          throw thrownValue;
+        });
+        return expect(io.run()).rejects.toBe(thrownValue);
+      })
+    ));
+
+  it("creates an IO which calls the returned 'cancel' function if the fiber is externally canceled", async () => {
+    let effectCalled = false;
+    let cancelCalled = false;
+
+    const fiberProgram = IO.cancelable(() => {
+      effectCalled = true;
+      const promise = new Promise((resolve) => setTimeout(resolve, 10));
+      return {
+        promise,
+        cancel() {
+          cancelCalled = true;
+        },
+      };
+    });
+
+    const io = Fiber.start(fiberProgram)
+      .through((fiber) => fiber.cancel())
+      .andThen((fiber) => fiber.outcome());
+
+    await io.run();
+
+    expect(effectCalled).toBe(true);
+    expect(cancelCalled).toBe(true);
+  });
+
+  it("creates an IO which raises when canceled if the 'cancel' function throws an error", async () => {
+    const fiberProgram = IO.cancelable(() => {
+      const promise = new Promise((resolve) => setTimeout(resolve, 10));
+      return {
+        promise,
+        cancel() {
+          throw "error";
+        },
+      };
+    });
+
+    const io = Fiber.start(fiberProgram)
+      .through((fiber) => fiber.cancel())
+      .andThen((fiber) => fiber.outcome());
+
+    const outcome = await io.run();
+
+    expect(outcome).toEqual(IOResult.Raised("error"));
   });
 });

--- a/tests/cancellation.test.ts
+++ b/tests/cancellation.test.ts
@@ -1,0 +1,22 @@
+import { CancellationError } from "../src/errors";
+import IO, { IOOutcome } from "../src/io";
+
+describe("The IO.cancel function", () => {
+  it("gives an IO which results in the 'canceled' outcome", async () => {
+    const result = await IO.cancel().runSafe();
+    expect(result).toEqual({ outcome: IOOutcome.Canceled });
+  });
+
+  it("gives an IO which throws a CancellationError if run directly", async () => {
+    expect(IO.cancel().run()).rejects.toEqual(new CancellationError());
+  });
+
+  it("prevents any subsequent actions from being run", async () => {
+    let subsequentEffectHasRun = false;
+    const io = IO.cancel().andThen(() =>
+      IO(() => (subsequentEffectHasRun = true))
+    );
+    await io.runSafe();
+    expect(subsequentEffectHasRun).toBe(false);
+  });
+});

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -82,10 +82,6 @@ describe("The IO.parallel function", () => {
   });
 
   it("rejects as soon as the first effect fails, without waiting for the others", async () => {
-    // This test currently causes jest to print a warning because the
-    // timer in the slow action is not cancelled, causing the process
-    // to stay active after the test run has finished. This should be
-    // resolved once the system supports cancellation.
     const events: Array<string> = [];
 
     const failsSlowly = IO.wait(30, "seconds")

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -159,7 +159,15 @@ describe("The IO.race function", () => {
     expect(outcome).toEqual(IOResult.Succeeded("result"));
   });
 
-  it("cancels the child fibers if the calling fiber is canceled", async () => {
+  /**
+   * TODO what is the best way to make this test pass?
+   *  - A) Implement a special case for IO.race and IO.parallel using Fiber.onCancel.
+   *  - B) Have cancellation of a fiber automatically propagate to all fibers it has
+   *       started.
+   *  - C) Have cancellation of a fiber propagate to any fiber which it is currently
+   *       awaiting the outcome of.
+   */
+  it.skip("cancels the child fibers if the calling fiber is canceled", async () => {
     let events: string[] = [];
 
     const io = Fiber.start(

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -126,6 +126,30 @@ describe("The IO.parallel function", () => {
       "starting action 3",
     ]);
   });
+
+  it.skip("cancels the child fibers if the calling fiber is canceled", async () => {
+    let events: string[] = [];
+
+    const io = Fiber.start(
+      IO.parallel([
+        IO(() => events.push("parallel IO 1 completed")).delay(
+          15,
+          "milliseconds"
+        ),
+        IO(() => events.push("parallel IO 2 completed")).delay(
+          10,
+          "milliseconds"
+        ),
+      ])
+    )
+      .andThen((fiber) => fiber.cancel())
+      .andThen(() => IO(() => events.push("calling fiber canceled")))
+      .andThen(() => IO.wait(20, "milliseconds"));
+
+    await io.runSafe();
+
+    expect(events).toEqual(["calling fiber canceled"]);
+  });
 });
 
 describe("The IO.race function", () => {

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -153,11 +153,7 @@ describe("The IO.parallel function", () => {
     expect(events).toEqual(["calling fiber canceled"]);
   });
 
-  // This test currently fails because there is a race condition. There is
-  // a microscopic gap between starting the fibers and setting up the
-  // "onCancel" handler. If the calling fiber is cancelled in this gap, the
-  // fibers will not be canceled.
-  it.only("cancels the child fibers if the calling fiber is canceled immediately", async () => {
+  it("cancels the child fibers if the calling fiber is canceled immediately", async () => {
     let events: string[] = [];
 
     const io = Fiber.start(

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -156,9 +156,8 @@ describe("The IO.parallel function", () => {
   // This test currently fails because there is a race condition. There is
   // a microscopic gap between starting the fibers and setting up the
   // "onCancel" handler. If the calling fiber is cancelled in this gap, the
-  // fibers will not be canceled. I think the way to fix this is to introduce
-  // an "uncancelable" mechanism.
-  it.skip("cancels the child fibers if the calling fiber is canceled immediately", async () => {
+  // fibers will not be canceled.
+  it.only("cancels the child fibers if the calling fiber is canceled immediately", async () => {
     let events: string[] = [];
 
     const io = Fiber.start(

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -142,6 +142,8 @@ describe("The IO.race function", () => {
       IO.raise(Error()),
     ]);
   });
+
+  it.todo("raises a cancellation error if all IOs cancel themselves");
 });
 
 describe("The repeatForever method", () => {

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -252,8 +252,7 @@ describe("The IO.race function", () => {
     expect(events).toEqual(["calling fiber canceled"]);
   });
 
-  // See equivalent test for description of the bug.
-  it.skip("cancels the child fibers if the calling fiber is canceled immediately", async () => {
+  it("cancels the child fibers if the calling fiber is canceled immediately", async () => {
     let events: string[] = [];
 
     const io = Fiber.start(

--- a/tests/delay.test.ts
+++ b/tests/delay.test.ts
@@ -7,8 +7,8 @@ describe("The delay method", () => {
       IO.wrap("result").delay(15, "milliseconds")
     );
 
-    expect(result.outcome).toBe(IOOutcome.Succeeded);
-    expect(result.value).toBe("result");
+    expect(result.outcome === IOOutcome.Succeeded).toBe(true);
+    expect((result as any).value).toBe("result");
     expect(timeoutTrace).toEqual([["setTimeout", 15, expect.anything()]]);
   });
 });

--- a/tests/fibers.test.ts
+++ b/tests/fibers.test.ts
@@ -1,0 +1,75 @@
+import { Fiber, IO, IOResult } from "../src/io";
+
+describe("The Fiber.start function", () => {
+  it("return an IO which runs the provided IO in an fiber, without blocking", async () => {
+    const eventsEmitted: string[] = [];
+
+    function emit(event: string): IO<void> {
+      return IO(() => void eventsEmitted.push(event));
+    }
+
+    const io = emit("before fiber starts")
+      .andThen(() =>
+        Fiber.start(emit("fiber is running").delay(20, "milliseconds"))
+      )
+      .andThen(() => emit("after fiber starts"))
+      .andThen(() => IO.wait(30, "milliseconds"))
+      .andThen(() => emit("after fiber finishes"));
+
+    await io.run();
+
+    expect(eventsEmitted).toEqual([
+      "before fiber starts",
+      "after fiber starts",
+      "fiber is running",
+      "after fiber finishes",
+    ]);
+  });
+});
+
+describe("The Fiber.outcome method", () => {
+  it("returns an IO which blocks execution until the fiber finishes", async () => {
+    const eventsEmitted: string[] = [];
+
+    function emit(event: string): IO<void> {
+      return IO(() => void eventsEmitted.push(event));
+    }
+
+    const io = emit("before fiber starts")
+      .andThen(() =>
+        Fiber.start(emit("fiber is running").delay(20, "milliseconds"))
+      )
+      .andThen((fiber) => fiber.outcome())
+      .andThen(() => emit("after fiber finishes"));
+
+    await io.run();
+
+    expect(eventsEmitted).toEqual([
+      "before fiber starts",
+      "fiber is running",
+      "after fiber finishes",
+    ]);
+  });
+
+  it("returns an IO which produces the fiber's outcome if the fiber succeeds", async () => {
+    const io = Fiber.start(IO.wrap("success")).andThen((fiber) =>
+      fiber.outcome()
+    );
+
+    await expect(io.run()).resolves.toEqual(IOResult.Succeeded("success"));
+  });
+
+  it("returns an IO which produces the fiber's outcome if the fiber raises an error", async () => {
+    const io = Fiber.start(IO.raise("error")).andThen((fiber) =>
+      fiber.outcome()
+    );
+
+    await expect(io.run()).resolves.toEqual(IOResult.Raised("error"));
+  });
+
+  it("returns an IO which produces the fiber's outcome if the fiber is canceled", async () => {
+    const io = Fiber.start(IO.cancel()).andThen((fiber) => fiber.outcome());
+
+    await expect(io.run()).resolves.toEqual(IOResult.Canceled);
+  });
+});

--- a/tests/ref.test.ts
+++ b/tests/ref.test.ts
@@ -1,0 +1,80 @@
+import fc from "fast-check";
+import IO from "../src/io";
+import { Ref } from "../src/ref";
+
+describe("the Ref class", () => {
+  it("can be created with an initial value", () =>
+    fc.assert(
+      fc.asyncProperty(fc.anything(), async (initialValue) => {
+        const program = Ref.create(initialValue).andThen(Ref.get);
+        const result = await program.run();
+        expect(result).toBe(initialValue);
+      })
+    ));
+
+  it("can be created empty, so the value is null", async () => {
+    const program = Ref.empty<number>().andThen((ref) => ref.get);
+    const result = await program.run();
+    expect(result).toBe(null);
+  });
+
+  it("can be updated using the set instance method", () =>
+    fc.assert(
+      fc.asyncProperty(
+        fc.anything(),
+        fc.anything(),
+        async (initialValue, newValue) => {
+          const program = Ref.create(initialValue)
+            .through((ref) => ref.set(newValue))
+            .andThen((ref) => ref.get);
+          const result = await program.run();
+          expect(result).toBe(newValue);
+        }
+      )
+    ));
+
+  it("can be updated using the set static method", () =>
+    fc.assert(
+      fc.asyncProperty(
+        fc.anything(),
+        fc.anything(),
+        async (initialValue, newValue) => {
+          const program = Ref.create(initialValue)
+            .through(Ref.set(newValue))
+            .andThen(Ref.get);
+          const result = await program.run();
+          expect(result).toBe(newValue);
+        }
+      )
+    ));
+
+  it("can be updated with a pure function using the modify instance method", () =>
+    fc.assert(
+      fc.asyncProperty(fc.integer(), async (initialValue) => {
+        const program = Ref.create(initialValue).andThen((ref) =>
+          // return a tuple of the result of "modify" and the ref's value
+          // afterwards, to check they are equal.
+          IO.sequence([ref.modify((x) => x + 1), ref.get] as const)
+        );
+
+        const result = await program.run();
+        expect(result[0]).toBe(initialValue + 1);
+        expect(result[1]).toBe(initialValue + 1);
+      })
+    ));
+
+  it("can be updated with a pure function using the modify static method", () =>
+    fc.assert(
+      fc.asyncProperty(fc.integer(), async (initialValue) => {
+        const program = Ref.create(initialValue).andThen((ref) =>
+          // return a tuple of the result of "modify" and the ref's value
+          // afterwards, to check they are equal.
+          IO.sequence([Ref.modify((x: number) => x + 1)(ref), ref.get] as const)
+        );
+
+        const result = await program.run();
+        expect(result[0]).toBe(initialValue + 1);
+        expect(result[1]).toBe(initialValue + 1);
+      })
+    ));
+});

--- a/tests/ref.test.ts
+++ b/tests/ref.test.ts
@@ -84,8 +84,8 @@ describe("the Ref class", () => {
     // wait a random number of milliseconds (between 0 and 10)
     // before incrementing the counter. This simulates many
     // concurrent fibers modifying the same ref. If any of the
-    // updates lost, the eventual total would incorrectly be
-    // less than 1000.
+    // updates were lost, the eventual total would incorrectly
+    // be less than 1000.
 
     const program = Ref.create(0)
       .through((ref) =>

--- a/tests/timeout.test.ts
+++ b/tests/timeout.test.ts
@@ -28,7 +28,7 @@ describe("The timeout method", () => {
         fc.integer({ min: 0, max: 8 }).map((x) => x * 5),
         fc.integer({ min: 0, max: 8 }).map((x) => x * 5),
         async (io, msToComplete, msToTimeout) => {
-          fc.pre(msToComplete <= msToTimeout);
+          fc.pre(msToComplete < msToTimeout);
           expect(
             await io
               .delay(msToComplete, "milliseconds")

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "include": [
+    "./**"
+  ]
+}

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../tsconfig.json",
   "include": [
-    "./**"
+    "./*"
   ]
 }

--- a/todo.md
+++ b/todo.md
@@ -30,8 +30,9 @@
 - [x] Rewrite `parallel` using fibers
 - [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
-- [x] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
-- [ ] Add a way to create atomic uncancelable sections to fix immediate cancellation race condition
+- [x] `IO.onCancel` method for resource cleanup
+- [ ] Add `IO.bracket` function for resource cleanup to fix immediate cancellation race condition
+- [ ] Add a way to create atomic uncancelable sections
 
 # Performance & Internals
 

--- a/todo.md
+++ b/todo.md
@@ -31,8 +31,17 @@
 - [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
 - [x] `IO.onCancel` method for resource cleanup
-- [ ] Add `IO.bracket` function for resource cleanup to fix immediate cancellation race condition
-- [ ] Add a way to create atomic uncancelable sections
+- [x] Add `IO.bracket` function for resource cleanup
+- [x] Add a way to create uncancelable sections
+
+# Data Structures
+
+- [x] Ref
+- [ ] Tests for Ref
+- [ ] Deferred?
+- [ ] Queue?
+- [ ] Batcher?
+- [ ] FiberPool - for limiting concurrency. Build on top of Queue?
 
 # Performance & Internals
 

--- a/todo.md
+++ b/todo.md
@@ -22,11 +22,13 @@
 - [x] Add Canceled to IOOutcome
 - [x] Add cancellation behaviour to run loop
 - [ ] Add a way to interoperate with other cancellation mechanisms e.g. `clearTimeout`
+- [ ] Support async `cancel` callbacks for `IO.cancelable`
 - [x] Fiber.start function
 - [x] Fiber.cancel method
 - [x] Fiber.outcome method
 - [ ] Rewrite `parallel` and `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
+- [ ] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
 
 # Performance & Internals
 

--- a/todo.md
+++ b/todo.md
@@ -21,12 +21,13 @@
 
 - [x] Add Canceled to IOOutcome
 - [x] Add cancellation behaviour to run loop
-- [ ] Add a way to interoperate with other cancellation mechanisms e.g. `clearTimeout`
+- [x] Add a way to interoperate with other cancellation mechanisms e.g. `clearTimeout`
 - [ ] Support async `cancel` callbacks for `IO.cancelable`
 - [x] Fiber.start function
 - [x] Fiber.cancel method
 - [x] Fiber.outcome method
-- [ ] Rewrite `parallel` and `race` using fibers
+- [ ] Rewrite `parallel` using fibers
+- [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
 - [ ] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
 

--- a/todo.md
+++ b/todo.md
@@ -30,7 +30,7 @@
 - [x] Rewrite `parallel` using fibers
 - [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
-- [ ] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
+- [x] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
 
 # Performance & Internals
 
@@ -45,6 +45,7 @@
 - [x] replace `IOInterface` and `methods` object with abstract base class
 - [ ] Use consistent terminology throughout - e.g. IO vs action vs effect
 - [ ] Rename `IOResult` to `Outcome` or `IOOutcome` and `IOOutcome` to `OutcomeKind`
+- [ ] Refactor `IO` implementation to take `executeOn` as a private member rather than using inheritance. This may make type errors easier to understand by removing the massive union type.
 
 ### Ergonomics Improvements
 

--- a/todo.md
+++ b/todo.md
@@ -21,10 +21,10 @@
 
 - [x] Add Canceled to IOOutcome
 - [x] Add cancellation behaviour to run loop
-- [ ] Add a way to interoperate with other cancellation mechanism e.g. `clearTimeout`
+- [ ] Add a way to interoperate with other cancellation mechanisms e.g. `clearTimeout`
 - [x] Fiber.start function
-- [ ] Fiber.cancel method
-- [ ] Fiber.join method
+- [x] Fiber.cancel method
+- [x] Fiber.outcome method
 - [ ] Rewrite `parallel` and `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
 

--- a/todo.md
+++ b/todo.md
@@ -48,6 +48,7 @@
 - [ ] Use consistent terminology throughout - e.g. IO vs action vs effect
 - [ ] Rename `IOResult` to `Outcome` or `IOOutcome` and `IOOutcome` to `OutcomeKind`
 - [ ] Refactor `IO` implementation to take `executeOn` as a private member rather than using inheritance. This may make type errors easier to understand by removing the massive union type.
+- [ ] Remove duplication between implementations of IO.race and IO.parallel.
 
 ### Ergonomics Improvements
 

--- a/todo.md
+++ b/todo.md
@@ -22,7 +22,7 @@
 - [x] Add Canceled to IOOutcome
 - [x] Add cancellation behaviour to run loop
 - [ ] Add a way to interoperate with other cancellation mechanism e.g. `clearTimeout`
-- [ ] IO.fork method (alternatively Fiber.start?)
+- [x] Fiber.start function
 - [ ] Fiber.cancel method
 - [ ] Fiber.join method
 - [ ] Rewrite `parallel` and `race` using fibers

--- a/todo.md
+++ b/todo.md
@@ -37,7 +37,7 @@
 # Data Structures
 
 - [x] Ref
-- [ ] Tests for Ref
+- [x] Tests for Ref
 - [ ] Deferred?
 - [ ] Queue?
 - [ ] Batcher?

--- a/todo.md
+++ b/todo.md
@@ -8,6 +8,7 @@
 - [x] sequence and parallel functions
 - [x] race function
 - [ ] finally method
+- [ ] catchAll method for unsoundly throw errors
 
 # Async, Concurrency & Fault Tolerance
 
@@ -26,7 +27,7 @@
 - [x] Fiber.start function
 - [x] Fiber.cancel method
 - [x] Fiber.outcome method
-- [ ] Rewrite `parallel` using fibers
+- [x] Rewrite `parallel` using fibers
 - [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
 - [ ] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)

--- a/todo.md
+++ b/todo.md
@@ -31,6 +31,7 @@
 - [x] Rewrite `race` using fibers
 - [x] IO.cancel function for a fiber to self-cancel
 - [x] `IO.onCancel` method for resource cleanup (do we need a full-blown bracket/resource construct?)
+- [ ] Add a way to create atomic uncancelable sections to fix immediate cancellation race condition
 
 # Performance & Internals
 

--- a/todo.md
+++ b/todo.md
@@ -43,6 +43,7 @@
 - [ ] work out how to split into several modules
 - [x] replace `IOInterface` and `methods` object with abstract base class
 - [ ] Use consistent terminology throughout - e.g. IO vs action vs effect
+- [ ] Rename `IOResult` to `Outcome` or `IOOutcome` and `IOOutcome` to `OutcomeKind`
 
 ### Ergonomics Improvements
 

--- a/todo.md
+++ b/todo.md
@@ -17,20 +17,23 @@
 - [x] exponential backoff for retry
 - [x] filter for retry
 
-Cancellation & Fibers
+# Cancellation & Fibers
 
-- [ ] Add Canceled to IOOutcome
-- [ ] Add cancellation behaviour to run loop
+- [x] Add Canceled to IOOutcome
+- [x] Add cancellation behaviour to run loop
+- [ ] Add a way to interoperate with other cancellation mechanism e.g. `clearTimeout`
 - [ ] IO.fork method (alternatively Fiber.start?)
 - [ ] Fiber.cancel method
 - [ ] Fiber.join method
-- [ ] IO.cancel function for a fiber to self-cancel
+- [ ] Rewrite `parallel` and `race` using fibers
+- [x] IO.cancel function for a fiber to self-cancel
 
 # Performance & Internals
 
 - [x] make recursive IO stack-safe
 - [ ] optimise to avoid creation of unnecessary promises
 - [ ] write some useful benchmarks - compare async/await/throw implementation to IO
+- [ ] Re-use the `Wrap`, `Raise` and `Cancel` class as the cases of `IOResult` to avoid allocations?
 
 # Code Organisation
 

--- a/todo.md
+++ b/todo.md
@@ -7,6 +7,7 @@
 - [x] correct type restrictions on errors
 - [x] sequence and parallel functions
 - [x] race function
+- [ ] finally method
 
 # Async, Concurrency & Fault Tolerance
 
@@ -15,8 +16,15 @@
 - [x] retry method
 - [x] exponential backoff for retry
 - [x] filter for retry
-- [ ] cancellation
-- [ ] fibers
+
+Cancellation & Fibers
+
+- [ ] Add Canceled to IOOutcome
+- [ ] Add cancellation behaviour to run loop
+- [ ] IO.fork method (alternatively Fiber.start?)
+- [ ] Fiber.cancel method
+- [ ] Fiber.join method
+- [ ] IO.cancel function for a fiber to self-cancel
 
 # Performance & Internals
 


### PR DESCRIPTION
This add several new concepts:
- `Canceled` is a third IO outcome, alongside `Succeeded` and `Raised`.
- A `Fiber` is an object representing an a logical thread of execution which is or was running an action.
- A fiber can cancel its own execution by calling `IO.cancel`.
- A fiber can be cancelled from another fiber by calling the `.cancel` method. This will stop the execution immediately, if the fiber is performing a compatible action.
- Impure async code can be wrapped to be compatible with cancellation using `IO.cancelable`.
- Code where cancellation at a certain point would cause bugs can use `IO.uncancelable` to delay cancellation until that action has completed. 
- Internal functions have been updated to ensure they are cancellation safe. They will not leave fibers running if they are canceled half way through.
